### PR TITLE
Add shortcut keys for minimizing and maximizing mentioned in #104

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -324,6 +324,18 @@ const createWindow = () => {
     var menu = Menu.buildFromTemplate(menuList)
     Menu.setApplicationMenu(menu)
 
+    globalShortcut.register('CommandOrControl+M', () => {
+        main_window.minimize()
+    })
+
+    globalShortcut.register('CommandOrControl+Shift+M', () => {
+        if (main_window.isMaximized()) {
+            main_window.restore();
+        } else {
+            main_window.maximize()
+        }
+    })
+
     ipcMain.handle('changeSettings', (event: Event, settings: Settings) => {
         log.info('STORING SETTINGS')
         log.info(settings)


### PR DESCRIPTION
Signed-off-by: Raymond Ley <raymond-ley@qq.com>

## Description

Added shortcut keys for minimizing and maximizing mentioned in #104 .

Considering that there are already minimized and maximized icons, only global shortcuts have been made, and no submenus have been registered to the view menu.

## Related Issues

Close #104 

## New Behavior

- Minimize using Ctrl+M
- Maximize using Ctrl+Shift+M
