### PR TITLE
Fix some cases where the scroll bar defaults to the middle

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -308,6 +308,16 @@ export default function Editor({ tabId }: { tabId: number }) {
                                     }
                                 ),
                             })
+                        } else {
+                            view.dispatch({
+                                effects: EditorView.scrollIntoView(
+                                    0,
+                                    {
+                                        y: 'start',
+                                        yMargin: 0,
+                                    }
+                                ),
+                            })
                         }
                         transactionDispatcher(view, transactions)
                         view.scrollDOM.addEventListener(


### PR DESCRIPTION
Signed-off-by: Raymond Ley <raymond-ley@qq.com>

## Description

Fixed an issue where scroll bars with less than one page of open file code are located in the middle by default.

E.g. something look like:

![cursor-scroll-issue](https://user-images.githubusercontent.com/36324984/227730709-8b74049e-0cfb-4bda-9724-4b3fdf31facd.png)

## Related Issues

None

## New Behavior

![cursor-scroll-fixed](https://user-images.githubusercontent.com/36324984/227731052-96bab105-a2d5-4906-94a6-c13c673afa5b.png)
