### PR TITLE
Support display of images

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -30,7 +30,7 @@ module.exports = {
             config: {
                 mainConfig: './webpack.main.config.js',
                 devContentSecurityPolicy:
-                    "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';",
+                    "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: file: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';",
                 renderer: {
                     config: './webpack.renderer.config.js',
                     entryPoints: [

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -352,6 +352,8 @@ export default function Editor({ tabId }: { tabId: number }) {
                         100
                     )}
                     value={cachedContent}
+                    fileName={fileName}
+                    filePath={filePath}
                     extensions={extensions}
                     initialState={initialState}
                 />

--- a/src/components/react-codemirror/index.tsx
+++ b/src/components/react-codemirror/index.tsx
@@ -21,6 +21,8 @@ export interface ReactCodeMirrorProps
     viewKey: number
     /** value of the auto created model in the editor. */
     value?: string
+    fileName?: string
+    filePath?: string
     height?: string
     minHeight?: string
     maxHeight?: string
@@ -126,6 +128,8 @@ export const ReactCodeMirror = forwardRef<
         root,
         initialState,
         tabId,
+        fileName,
+        filePath,
         ...other
     } = props
     const editor = useRef<HTMLDivElement>(null)
@@ -172,14 +176,33 @@ export const ReactCodeMirror = forwardRef<
 
     const defaultClassNames =
         typeof theme === 'string' ? `cm-theme-${theme}` : 'cm-theme'
+
+    function isImageFile(fileName: string): boolean {
+        const imageExtensions = ['png', 'jpg', 'jpeg', 'gif', 'svg']
+        const extension = fileName.split('.').pop()?.toLowerCase()
+        return extension !== undefined && imageExtensions.includes(extension)
+    }
+
+    const isImage = fileName && isImageFile(fileName)
+
     return (
-        <div
-            ref={editor}
-            className={`${defaultClassNames}${
-                className ? ` ${className}` : ''
-            }`}
-            {...other}
-        ></div>
+        <>
+            {isImage ? (
+                <img
+                    src={`file://${filePath}`}
+                    alt={fileName}
+                    style={{ maxWidth: '100%', maxHeight: '100%' }}
+                />
+            ) : (
+                <div
+                    ref={editor}
+                    className={`${defaultClassNames}${
+                        className ? ` ${className}` : ''
+                    }`}
+                    {...other}
+                ></div>
+            )}
+        </>
     )
 })
 

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';"
+            content="default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: file: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';"
         />
         <meta charset="UTF-8" />
         <script

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -113,7 +113,8 @@ process.on('unhandledRejection', (error) => {
 })
 
 const createWindow = () => {
-    const width = 1500, height = 800;
+    const width = 1500,
+        height = 800
     // Create the browser window.
     const main_window = new BrowserWindow({
         ...(process.platform === 'darwin'
@@ -254,7 +255,7 @@ const createWindow = () => {
                 },
                 {
                     label: 'Redo',
-                    accelerator: META_KEY+'Shift+Z',
+                    accelerator: META_KEY + 'Shift+Z',
                     selector: 'redo:',
                 },
                 { type: 'separator' },
@@ -335,14 +336,14 @@ const createWindow = () => {
     globalShortcut.register(META_KEY + '+=', () => {
         main_window.webContents.send('zoom_in')
     })
-    
+
     globalShortcut.register('CommandOrControl+M', () => {
         main_window.minimize()
     })
 
     globalShortcut.register('CommandOrControl+Shift+M', () => {
         if (main_window.isMaximized()) {
-            main_window.restore();
+            main_window.restore()
         } else {
             main_window.maximize()
         }
@@ -531,10 +532,17 @@ const createWindow = () => {
 
     log.info('setting up handle get_file')
     ipcMain.handle('get_file', async function (event: Event, filePath: string) {
-        // read the file and return the contents
-        var data = ''
+        // Check if the file is an image
+        const extension = filePath.split('.').pop()?.toLowerCase()
+        const isImage = ['jpg', 'jpeg', 'png', 'gif', 'bmp'].includes(
+            extension || ''
+        )
+
+        // Read the file using the binary encoding if it's an image
+        const encoding = isImage ? 'binary' : 'utf8'
+        let data = ''
         try {
-            data = await fileSystem.readFileSync(filePath, 'utf8')
+            data = await fileSystem.readFileSync(filePath, encoding)
         } catch {
             data = ''
         }
@@ -891,7 +899,7 @@ const modifyHeaders = () => {
                     {
                         ...details.responseHeaders,
                         'Content-Security-Policy': [
-                            "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';",
+                            "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: file: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';",
                         ],
                     },
                     details.responseHeaders


### PR DESCRIPTION
Check if we are loading an image and use `binary` instead of `utf8` to load it.
Next, use the `file:` protocol to display it in the editor tab.

Example:
<img width="312" alt="Screenshot 2023-03-25 at 18 11 38" src="https://user-images.githubusercontent.com/37532050/227734300-5a2d3402-c8b3-4803-a1e4-fc3c58358eec.png">


Fixes https://github.com/getcursor/cursor/issues/8 (partly)
