### PR TITLE
Auto scroll to input box in chatbox

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -278,6 +278,15 @@ export function ChatPopup() {
     const messages = useAppSelector(csel.getCurrentConversationMessages())
     const filePath = useAppSelector(getCurrentFilePath)
 
+    const commandBoxRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if(!isGenerating && commandBoxRef) {
+            setTimeout(() => {
+                commandBoxRef.current?.scrollIntoView({ behavior: "smooth" });
+            }, 100)
+        }
+    }, [isGenerating]);
     const onApply = () => {
         dispatch(ct.pressAICommand('k'))
         dispatch(cs.setCurrentDraftMessage('Make the chanage'))
@@ -350,6 +359,7 @@ export function ChatPopup() {
                                 'opacity-100': !isGenerating,
                                 'opacity-0': isGenerating,
                             })}
+                            ref={commandBoxRef}
                         >
                             {!isGenerating && (
                                 <CommandBar parentCaller={'chat'} />

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -278,7 +278,7 @@ export function ChatPopup() {
     const messages = useAppSelector(csel.getCurrentConversationMessages())
     const filePath = useAppSelector(getCurrentFilePath)
 
-    const commandBoxRef = useRef<HTMLDivElement>(null);
+    const commandBoxRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
         if(!isGenerating && commandBoxRef) {
@@ -286,7 +286,8 @@ export function ChatPopup() {
                 commandBoxRef.current?.scrollIntoView({ behavior: "smooth" });
             }, 100)
         }
-    }, [isGenerating]);
+    }, [isGenerating])
+
     const onApply = () => {
         dispatch(ct.pressAICommand('k'))
         dispatch(cs.setCurrentDraftMessage('Make the chanage'))


### PR DESCRIPTION
closes [#181](https://github.com/getcursor/cursor/issues/246)
closes https://github.com/getcursor/cursor/issues/146

This change is to automatically scroll to the position of the TextInput when the bot finishes answering, optimized performance is as follows.

https://user-images.githubusercontent.com/6027456/227758043-26a8a02a-4424-42d2-a8c1-11fb4652009d.mov


