### PR TITLE
Resetting to `fileTree` view when opening a new repo

### DIFF
--- a/src/features/globalSlice.ts
+++ b/src/features/globalSlice.ts
@@ -84,6 +84,7 @@ import { LSPNotifyMap } from './lsp/stdioClient'
 import { CustomTransaction } from '../components/codemirrorHooks/dispatch'
 import { changeSettings } from './settings/settingsSlice'
 import { updateCommentsForFile } from './comment/commentSlice'
+import { openFileTree } from './tools/toolSlice'
 import { updateTestsForFile } from './tests/testSlice'
 import { getPane } from './selectors'
 
@@ -635,6 +636,8 @@ export const openFolder = createAsyncThunk(
             dispatch(setRemoteCommand(remote.remoteCommand))
         if (remote != null && remote.remotePath != null)
             dispatch(setRemotePath(remote.remotePath))
+
+        dispatch(openFileTree())
     }
 )
 

--- a/src/features/globalSlice.ts
+++ b/src/features/globalSlice.ts
@@ -613,6 +613,9 @@ export const openFolder = createAsyncThunk(
 
         dispatch(overwriteFolder({ folderPath, folderData }))
 
+        // Show the new folder in the FileTree view
+        dispatch(openFileTree())
+
         // Now we are going to setup the lsp server
         await dispatch(startConnections(folderPath))
 
@@ -636,8 +639,6 @@ export const openFolder = createAsyncThunk(
             dispatch(setRemoteCommand(remote.remoteCommand))
         if (remote != null && remote.remotePath != null)
             dispatch(setRemotePath(remote.remotePath))
-
-        dispatch(openFileTree())
     }
 )
 


### PR DESCRIPTION
Fixes #59 