### PR TITLE
Fix `setup.sh` and sort files on search

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,8 +2,8 @@
 wget https://cursor.so/resources.zip
 wget https://cursor.so/lsp.zip
 
-unzip resources.zip -d resources/
-unzip lsp.zip -d lsp/
+unzip resources.zip
+unzip lsp.zip
 
 rm ./resources.zip
 rm ./lsp.zip

--- a/src/main/search.ts
+++ b/src/main/search.ts
@@ -29,7 +29,7 @@ const searchRipGrep = async (
 ) => {
     // Instead run ripgrep fromt the cli
     // let cmd = ['rg', '--json', '--line-number', '--with-filename']
-    let cmd = ['--json', '--line-number', '--with-filename']
+    let cmd = ['--json', '--line-number', '--with-filename', '--sort-files']
     if (arg.caseSensitive) {
         cmd.push('--case-sensitive')
     } else {


### PR DESCRIPTION
1. With the current `setup.sh`, files are unpacked in `resources/resources` and `lsp/lsp`.
This means that locally the `search` doesn't work because it looks for `rg` in `resources/darwin/..`, not in the `resources/resources` folder.

2. Added the `--sort-files` flag to sort the files in the result of the search

Fixes https://github.com/getcursor/cursor/issues/13