### PR TITLE
Updated path when opening new folder

### DIFF
--- a/src/features/globalSlice.ts
+++ b/src/features/globalSlice.ts
@@ -552,6 +552,7 @@ export const openRemoteFolder = createAsyncThunk(
         if (repoId != null) {
             dispatch(setRepoId(repoId))
             dispatch(syncProject(null))
+            dispatch(setTermialPath(folderPath))
         } else {
             dispatch(initializeIndex(null))
         }
@@ -627,6 +628,7 @@ export const openFolder = createAsyncThunk(
         if (repoId != null) {
             dispatch(setRepoId(repoId))
             dispatch(syncProject(null))
+            dispatch(setTermialPath(folderPath))
         } else {
             dispatch(initializeIndex(null))
         }
@@ -749,6 +751,13 @@ export const initState = createAsyncThunk(
             dispatch(setRemoteCommand(remote.remoteCommand))
         if (remote != null && remote.remotePath != null)
             dispatch(setRemotePath(remote.remotePath))
+    }
+)
+
+export const setTermialPath = createAsyncThunk(
+    'global/setTermialPath',
+    async (path: string, { getState, dispatch }) => {
+        await connector.setTermialPath(path)
     }
 )
 

--- a/src/main/terminal.ts
+++ b/src/main/terminal.ts
@@ -2,7 +2,7 @@ import os from 'os'
 import * as pty from 'node-pty'
 
 import { ipcMain } from 'electron'
-
+import log from 'electron-log'
 export function setupTerminal(mainWindow: any, rootPath?: string) {
     let shells =
         os.platform() === 'win32' ? ['powershell.exe'] : ['zsh', 'bash']
@@ -34,6 +34,15 @@ export function setupTerminal(mainWindow: any, rootPath?: string) {
     }
 
     if (ptyProcess == null) return
+
+    ipcMain.handle(
+        'set-terminal-path',
+        async function (event: any, path: string) {
+            ptyProcess.kill('SIGINT')
+            ptyProcess.write(`cd ${path}\n`)
+            ptyProcess.write(`clear \n`)
+        }
+    )
     ipcMain.handle('terminal-into', (event, data) => {
         ptyProcess.write(data)
     })

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -190,7 +190,8 @@ const electronConnector = {
     },
     terminalInto: (data: any) => ipcRenderer.invoke('terminal-into', data),
     terminalResize: (data: any) => ipcRenderer.invoke('terminal-resize', data),
-
+    setTermialPath: (path: string) =>
+        ipcRenderer.invoke('set-terminal-path', path),
     registerFileWasAdded: (callback: Callback) =>
         ipcRenderer.on('fileWasAdded', callback),
     registerFileWasDeleted: (callback: Callback) =>


### PR DESCRIPTION
#232 and #236 pointed out that currently when opening a folder the terminal does not update to the new path because setupTerminal does not get invoked again. We dont need to destroy and create a new terminal as currently we only support one terminal at a time