### PR TITLE
Don't set isChatOpen on every response

### DIFF
--- a/src/features/chat/chatSlice.ts
+++ b/src/features/chat/chatSlice.ts
@@ -108,7 +108,7 @@ export const chatSlice = createSlice({
                 useDiagnostics?: boolean | number
             }>
         ) {
-            chatState.chatIsOpen = true
+//             chatState.chatIsOpen = true
 
             const lastUserMessage = chatState.userMessages.at(-1)!
             const type = action.payload.type


### PR DESCRIPTION
Fixes: https://github.com/getcursor/cursor/issues/295. Interested in where this is relied on/why it was introduced, the git blame isn't really helpful there. We may need a conditional, but this fixes the keyboard shortcuts at least.