### PR TITLE
feat: Add CLI folder opening support

### DIFF
--- a/src/features/listeners.ts
+++ b/src/features/listeners.ts
@@ -64,7 +64,7 @@ connector.registerCloseAllTabs(() => {
 })
 // @ts-ignore
 connector.openFolderOn((path) => {
-    store.dispatch(gs.openFolder({path}))
+    store.dispatch(gs.openFolder({ path }))
 })
 
 // @ts-ignore

--- a/src/features/listeners.ts
+++ b/src/features/listeners.ts
@@ -62,6 +62,10 @@ connector.registerCloseTab(() => {
 connector.registerCloseAllTabs(() => {
     store.dispatch(gt.closeAllTabs())
 })
+// @ts-ignore
+connector.openFolderOn((path) => {
+    store.dispatch(gs.openFolder({path}))
+})
 
 // @ts-ignore
 connector.registerOpenFolder(() => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -176,11 +176,11 @@ const createWindow = () => {
         return { action: 'deny' }
     })
 
-    main_window.webContents.on('did-finish-load',()=>{
-        const currentWorkingDir = process.cwd();
-        const args = process.argv;
-        const argsPath = args[1] ? path.join(currentWorkingDir, args[1]) : null;
-        if(argsPath !== null){
+    main_window.webContents.on('did-finish-load', () => {
+        const currentWorkingDir = process.cwd()
+        const args = process.argv
+        const argsPath = args[1] ? path.join(currentWorkingDir, args[1]) : null
+        if (argsPath !== null) {
             main_window.webContents.send('open_folder', argsPath)
         }
     })

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -176,6 +176,14 @@ const createWindow = () => {
         return { action: 'deny' }
     })
 
+    main_window.webContents.on('did-finish-load',()=>{
+        const currentWorkingDir = process.cwd();
+        const args = process.argv;
+        const argsPath = args[1] ? path.join(currentWorkingDir, args[1]) : null;
+        if(argsPath !== null){
+            main_window.webContents.send('open_folder', argsPath)
+        }
+    })
     if (!app.isPackaged) {
         main_window.webContents.openDevTools()
     }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -311,6 +311,8 @@ const electronConnector = {
 
     registerCloseAllTabs: (callback: Callback) =>
         ipcRenderer.on('close_all_tabs_click', callback),
+    openFolderOn: (callback: (path:string)=>void) =>
+    ipcRenderer.on('open_folder', (_event, path) => callback(path)),
     openFolder: () => ipcRenderer.invoke('open_folder', null),
     registerOpenFolder: (callback: Callback) =>
         ipcRenderer.on('open_folder_triggered', callback),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -311,8 +311,8 @@ const electronConnector = {
 
     registerCloseAllTabs: (callback: Callback) =>
         ipcRenderer.on('close_all_tabs_click', callback),
-    openFolderOn: (callback: (path:string)=>void) =>
-    ipcRenderer.on('open_folder', (_event, path) => callback(path)),
+    openFolderOn: (callback: (path: string) => void) =>
+        ipcRenderer.on('open_folder', (_event, path) => callback(path)),
     openFolder: () => ipcRenderer.invoke('open_folder', null),
     registerOpenFolder: (callback: Callback) =>
         ipcRenderer.on('open_folder_triggered', callback),


### PR DESCRIPTION
Implemented the ability to open the Cursor app with a specified folder by passing a folder path as a command-line argument. Users can now launch the app and directly open a folder by running ` cursor <folder_path>`.

closes #3  