### PR TITLE
feat: optimized the style of chat

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -348,24 +348,26 @@ export function ChatPopup() {
                     }}
                 >
                     {/* Subtle padding to separate content from scroll bar*/}
-                    <div className="px-4 overflow-auto">
-                        <div className="markdownpopup__dismiss h-8 flex items-center">
-                            <CommandBarActionTips tips={commandBarActionTips} />
+                    <div>
+                        <div className="markdownpopup__dismiss h-8 flex flex-col mt-3  items-center">
+                                <CommandBarActionTips tips={commandBarActionTips} />
                         </div>
-                        <div className="flex flex-col space-y-2">
-                            {markdownPopups}
-                        </div>
-                        <div
-                            className={cx('my-4', {
-                                'opacity-100': !isGenerating,
-                                'opacity-0': isGenerating,
-                            })}
-                            ref={commandBoxRef}
-                        >
-                            {!isGenerating && (
-                                <CommandBar parentCaller={'chat'} />
-                            )}
-                        </div>
+                      <div className="chatpopup__content  px-4 overflow-auto ">
+                            <div className="flex flex-col space-y-2">
+                                {markdownPopups}
+                            </div>
+                            <div
+                                className={cx('my-4', {
+                                    'opacity-100': !isGenerating,
+                                    'opacity-0': isGenerating,
+                                })}
+                                ref={commandBoxRef}
+                            >
+                                {!isGenerating && (
+                                    <CommandBar parentCaller={'chat'} />
+                                )}
+                            </div>
+                      </div>
                     </div>
                     {isChatHistoryOpen && (
                         <ChatHistory onSelect={handleSelectHistory} />
@@ -759,7 +761,7 @@ function formatPromptTime(sentAt: number): string {
     const hours = date.getHours()
     const minutes = date.getMinutes()
     const ampm = hours >= 12 ? 'pm' : 'am'
-    const formattedHours = hours % 12 === 0 ? 12 : hours % 12
+    const formattedHours = hours % 12  ? 12 : hours % 12
     const formattedMinutes = minutes < 10 ? `0${minutes}` : minutes
     return `${formattedHours}:${formattedMinutes}${ampm}`
 }
@@ -798,7 +800,7 @@ function ChatHistory(props: {
                     return (
                         <button
                             key={msg.conversationId}
-                            className="w-full bg-neutral-600 rounded-sm px-4 py-2 "
+                            className="w-full bg-neutral-600 rounded-sm px-4 py-2"
                             onClick={() => props.onSelect?.(msg.conversationId)}
                         >
                             <div
@@ -806,10 +808,10 @@ function ChatHistory(props: {
                                     'flex justify-between whitespace-nowrap items-center'
                                 }
                             >
-                                <span className="text-neutral-300 text-xs customEllipsis">
+                                <span className="text-neutral-300 text-base customEllipsis">
                                     {formatPromptPreview(msg.message)}
                                 </span>
-                                <span className="text-neutral-400 text-xs">
+                                <span className="text-neutral-400 text-base">
                                     {formatPromptTime(msg.sentAt)}
                                 </span>
                             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -101,10 +101,7 @@ body {
 }
 .customEllipsis:after {
     content: '"';
-    display: block;
-    position: absolute;
-    top: 0;
-    right: 0;
+    margin-left: 2px;
 }
 
 .cm-content {
@@ -1367,6 +1364,10 @@ cm-diff-cancel > div {
     width: fit-content;
     cursor: pointer;
     color: #eee;
+}
+
+.chatpopup__content {
+    max-height: 76vh;
 }
 
 .markdownpopup .cm-content {


### PR DESCRIPTION
This pr mainly solves two issue, can find more details on attached screenshots.
1. make the actionTip sticky on the chat top.
2. fix some style issue in chat history.

 **make the actionTip sticky on the chat top.**

before:  the action button will be covered when scroll up.
<img width="455" alt="screenShot" src="https://user-images.githubusercontent.com/97930813/229152924-8aecd088-3413-44d3-99a3-54dd7ee35e1d.png">

after: sticky on the chat top so people can click it without scrolling up, which is pretty hard when the response is long.
<img width="443" alt="screenShot" src="https://user-images.githubusercontent.com/97930813/229151585-c78851ea-d13c-430c-9457-91167f2bf97e.png">

**fix style issue in chat history.**

before: The colon will overwrite the last character if the text is not elliptical and the font size is too small.
<img width="279" alt="screenShot" src="https://user-images.githubusercontent.com/97930813/229154185-66cfa815-0751-45e1-97b3-d694d086f68a.png">
after: show normal and change the font size to text-base.
<img width="279" alt="screenShot" src="https://user-images.githubusercontent.com/97930813/229154519-3f6b11ad-32ce-4d73-9071-4185f110a735.png">






