### PR TITLE
Better Comments Extension

### DIFF
--- a/src/components/settingsPane.tsx
+++ b/src/components/settingsPane.tsx
@@ -1,9 +1,8 @@
-import { useAppDispatch, useAppSelector } from '../app/hooks'
-
-import { Switch } from '@headlessui/react'
-import { HOMEPAGE_ROOT } from '../utils'
+import 'react-dropdown/style.css'
 
 import * as ssel from '../features/settings/settingsSelectors'
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
     changeSettings,
     toggleSettings,
@@ -16,26 +15,29 @@ import {
     runLanguageServer,
     stopLanguageServer,
 } from '../features/lsp/languageServerSlice'
-// REMOVED CODEBASE-WIDE FEATURES!
-// import { initializeIndex } from '../features/globalSlice'
-
-import Dropdown from 'react-dropdown'
-import 'react-dropdown/style.css'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
     copilotStatus,
     getLanguages,
     languageServerStatus,
 } from '../features/lsp/languageServerSelector'
-
 import {
     signInCursor,
     signOutCursor,
     upgradeCursor,
 } from '../features/tools/toolSlice'
+import { useAppDispatch, useAppSelector } from '../app/hooks'
+
+import Dropdown from 'react-dropdown'
+import { HOMEPAGE_ROOT } from '../utils'
+import Modal from 'react-modal'
+import { Switch } from '@headlessui/react'
 import { loginStatus } from '../features/tools/toolSelectors'
 
-import Modal from 'react-modal'
+// REMOVED CODEBASE-WIDE FEATURES!
+// import { initializeIndex } from '../features/globalSlice'
+
+
+
 
 export function SettingsPopup() {
     const dispatch = useAppDispatch()
@@ -139,6 +141,26 @@ export function SettingsPopup() {
                                         )
                                     }}
                                     value={settings.textWrapping}
+                                />
+                            </div>
+
+                            <div className="settings__item">
+                                <div className="settings__item_title">
+                                    Enable Better Comments
+                                </div>
+                                <div className="settings__item_description">
+                                    Controls whether better comments is enabled
+                                </div>
+                                <Dropdown
+                                    options={['enabled', 'disabled']}
+                                    onChange={(e) => {
+                                        dispatch(
+                                            changeSettings({
+                                                betterComments: e.value,
+                                            })
+                                        )
+                                    }}
+                                    value={settings.betterComments}
                                 />
                             </div>
 

--- a/src/features/extensions/betterComments.ts
+++ b/src/features/extensions/betterComments.ts
@@ -1,0 +1,108 @@
+import {Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate, WidgetType} from "@codemirror/view"
+import { Tag, getStyleTags, tags } from "@lezer/highlight";
+
+import { RangeSetBuilder } from "@codemirror/state";
+import { Tree } from "@lezer/common";
+import { syntaxTree } from "@codemirror/language";
+
+class CommentsHighlighter {
+    decorations: DecorationSet
+    tree: Tree
+    markCache: { [cls: string]: Decoration } = Object.create(null)
+
+    constructor(view: EditorView) {
+        this.tree = syntaxTree(view.state)
+        this.decorations = this.buildDeco(view)
+    }
+
+    update(update: ViewUpdate) {
+        const tree = syntaxTree(update.state)
+        if (tree != this.tree || update.viewportChanged) {
+            this.tree = tree
+            this.decorations = this.buildDeco(update.view)
+        }
+    }
+
+    buildDeco(_view: EditorView) {
+        if (!this.tree.length) return Decoration.none
+
+        const builder = new RangeSetBuilder<Decoration>()
+        const cursor = this.tree.cursor()
+        do {
+            const tagData = getStyleTags(cursor.node)
+            const tags = tagData?.tags?.map(getTagName);
+
+
+            if(tags?.includes('lineComment')) {
+
+                const { state } = _view
+                const textContent = state.doc.sliceString(cursor.from, cursor.to)
+                const className = colorClasses[textContent.slice(0, 3)] || colorClasses[textContent.slice(0, 6)]
+
+                builder.add(cursor.from, cursor.to, Decoration.widget({ widget: new CommentWidget(textContent, className) }))
+            }
+
+        } while (cursor.next())
+        return builder.finish()
+    }
+}
+
+const colorClasses: Record<string, string> = {
+    '//!': 'cm-betterComments-alert',
+    '//?': 'cm-betterComments-question',
+    '//TODO': 'cm-betterComments-todo',
+    '//*': 'cm-betterComments-highlighted',
+}
+
+export function betterComments (isEnabled = false) { 
+    if (!isEnabled) return []
+
+    return [
+        EditorView.baseTheme({
+            ".cm-betterComments-lineComment": { color: "#6a9955" },
+            ".cm-betterComments-highlighted": { color: "#98C379" },
+            ".cm-betterComments-todo": { color: "#FF8C00" },
+            ".cm-betterComments-question": { color: "#3498DB" },
+            ".cm-betterComments-alert": { color: "#FF2D00" },
+        }), 
+        ViewPlugin.fromClass(CommentsHighlighter, {
+            decorations: (v) => v.decorations,
+        })
+    ]
+}
+
+//! probably should be exported to a common folder
+const getTagName = (tag: Tag) => {
+    for (const key of Object.keys(tags)) {
+        // Turn key to string
+        const keyString = key.toString() as keyof typeof tags
+        const currentTag = tags[keyString]
+
+        if ('id' in currentTag && 'id' in tag) {
+            if (currentTag.id === tag.id) {
+                return keyString
+            }
+        }
+    }
+}
+
+class CommentWidget extends WidgetType {
+    constructor(
+        private readonly textContent: string,
+        private readonly className?: string
+    ) {
+        super()
+    }
+
+
+    toDOM() {
+        const wrap = document.createElement('span')
+        wrap.className = this.className || 'cm-comment cm-betterComments-lineComment'
+        wrap.textContent = this.textContent
+        return wrap
+    }
+
+    ignoreEvent(): boolean {
+        return true
+    }
+}

--- a/src/features/window/state.ts
+++ b/src/features/window/state.ts
@@ -1,7 +1,7 @@
 import { Action } from '@reduxjs/toolkit'
 import { CustomTransaction } from '../../components/codemirrorHooks/dispatch'
-import { v4 as uuidv4 } from 'uuid'
 import { ExpectedError } from '../../utils'
+import { v4 as uuidv4 } from 'uuid'
 
 export interface File {
     parentFolderId: number
@@ -306,6 +306,7 @@ export interface Settings {
     useOpenAIKey?: boolean
     openAIModel?: string
     tabSize?: string
+    betterComments: string
 }
 
 export interface SettingsState {
@@ -412,6 +413,7 @@ export const initialSettingsState = {
         contextType: 'none',
         textWrapping: 'disabled',
         tabSize: undefined,
+        betterComments: 'enabled',
     },
 }
 

--- a/src/features/window/state.ts
+++ b/src/features/window/state.ts
@@ -413,7 +413,7 @@ export const initialSettingsState = {
         contextType: 'none',
         textWrapping: 'disabled',
         tabSize: undefined,
-        betterComments: 'enabled',
+        betterComments: 'disabled',
     },
 }
 


### PR DESCRIPTION
I added better comments extension inspired from https://github.com/aaron-bond/better-comments. There's option to disable from settings.
I'm not sure on my implementation because I've never worked with code mirror before. Plus this is my first open source contribution. More to come 🫡

<img width="502" alt="image" src="https://user-images.githubusercontent.com/10860131/229289359-7b9b27d6-23d4-4459-82c7-2c7d9741e8f7.png">

**Known Bugs**
Using left/right arrow key moves the cursor to start/end of the line, it doesn't move between letters. I've been figuring it out for a while but no luck, so help is much appreciated here.