### PR TITLE
feat: show history list under the command bar and fix select logic

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -4,7 +4,11 @@ import {
     faTimes,
 } from '@fortawesome/free-solid-svg-icons'
 import { faChevronsLeft } from '@fortawesome/pro-regular-svg-icons'
-import { setChatOpen, toggleChatHistory } from '../features/chat/chatSlice'
+import {
+    setChatHistoryOpen,
+    setChatOpen,
+    toggleChatHistory,
+} from '../features/chat/chatSlice'
 import { store } from './store'
 
 export type Tip = [string, string, IconDefinition, () => void]
@@ -24,5 +28,11 @@ export const ActionTips: ActionTipsInterface = {
         'Cmd+H',
         faChevronsLeft,
         () => store.dispatch(toggleChatHistory()),
+    ],
+    CLOSE_HISTORY_DIRECTLY: [
+        'Close History Directly',
+        '',
+        faTimes,
+        () => store.dispatch(setChatHistoryOpen(false)),
     ],
 }

--- a/src/components/settingsPane.tsx
+++ b/src/components/settingsPane.tsx
@@ -219,8 +219,9 @@ export function OpenAILoginPanel({ onSubmit }: { onSubmit: () => void }) {
                 changeSettings({
                     openAIKey: localAPIKey,
                     useOpenAIKey: true,
-                    openAIModel: models.at(0) ?? null
-                }))
+                    openAIModel: models.at(0) ?? null,
+                })
+            )
             onSubmit()
         }
     }, [dispatch, localAPIKey])
@@ -346,11 +347,11 @@ export function OpenAIPanel() {
                 changeSettings({
                     openAIKey: localAPIKey,
                     useOpenAIKey: true,
-                    openAIModel: models.at(0) ?? null
-                }))
+                    openAIModel: models.at(0) ?? null,
+                })
+            )
         }
     }, [dispatch, localAPIKey])
-
 
     return (
         <div className="settings__item">
@@ -485,13 +486,13 @@ export function CursorLogin({
                     <div className="copilot__signin">
                         <button onClick={signOut}>Log out</button>
                         {showSettings && (
-                    <>
-                        <br />
-                        <button onClick={openAccountSettings}>
-                            Manage settings
-                        </button>
-                    </>
-                )}
+                            <>
+                                <br />
+                                <button onClick={openAccountSettings}>
+                                    Manage settings
+                                </button>
+                            </>
+                        )}
                     </div>
                 </div>
             )
@@ -499,20 +500,22 @@ export function CursorLogin({
             currentPanel = (
                 <>
                     <div className="settings__item">
-                        <div className="settings__item_title">Cursor Account</div>
+                        <div className="settings__item_title">
+                            Cursor Account
+                        </div>
                         <div className="settings__item_description">
                             Login to use the AI without an API key
                         </div>
                         <div className="copilot__signin">
                             <button onClick={signOut}>Log out</button>
                             {showSettings && (
-                    <>
-                        <br />
-                        <button onClick={openAccountSettings}>
-                            Manage settings
-                        </button>
-                    </>
-                )}
+                                <>
+                                    <br />
+                                    <button onClick={openAccountSettings}>
+                                        Manage settings
+                                    </button>
+                                </>
+                            )}
                             <br />
                         </div>
                     </div>
@@ -522,7 +525,7 @@ export function CursorLogin({
                             Upgrade for unlimited generations
                         </div>
                         <div className="copilot__signin">
-                        <button onClick={upgrade}>Upgrade to Pro</button>
+                            <button onClick={upgrade}>Upgrade to Pro</button>
                         </div>
                     </div>
                 </>
@@ -530,9 +533,7 @@ export function CursorLogin({
         }
     }
 
-    return (
-            currentPanel
-    )
+    return currentPanel
 }
 
 function CopilotPanel() {

--- a/src/features/chat/chatSelectors.ts
+++ b/src/features/chat/chatSelectors.ts
@@ -158,3 +158,6 @@ export const getIsChatHistoryAvailable = createSelector(
 export const getFireCommandK = (state: FullState) =>
     state.chatState.fireCommandK
 export const getMsgType = (state: FullState) => state.chatState.msgType
+
+export const getHistoryStatus = (state: FullState) =>
+    state.chatState.chatHistoryIsOpen

--- a/src/features/chat/chatSlice.ts
+++ b/src/features/chat/chatSlice.ts
@@ -320,6 +320,7 @@ export const chatSlice = createSlice({
         openCommandBar(chatState: ChatState) {
             chatState.isCommandBarOpen = true
             chatState.chatIsOpen = false
+            chatState.chatHistoryIsOpen = true
             const newConversationId = uuidv4()
 
             chatState.currentConversationId = newConversationId
@@ -525,18 +526,26 @@ export const chatSlice = createSlice({
                 chatState.commandBarHistoryIndex
 
             const historyMessage = chatState.userMessages.at(index)
+            const currentConversationId = chatState.currentConversationId
+            const currentDraftMessage =
+                chatState.draftMessages[currentConversationId]
             if (historyMessage) {
                 // chatState.currentConversationId = historyMessage.conversationId
-                const currentConversationId = chatState.currentConversationId
-                const currentDraftMessage =
-                    chatState.draftMessages[currentConversationId]
                 currentDraftMessage.message = historyMessage.message
+            } else {
+                currentDraftMessage.message = ''
             }
             // if (historyMessage) {
             //     chatState.commandBarText = historyMessage.message
             // } else {
             //     chatState.commandBarText = ''
             // }
+        },
+        setChatHistoryOpen(
+            chatState: ChatState,
+            action: PayloadAction<boolean>
+        ) {
+            chatState.chatHistoryIsOpen = action.payload
         },
     },
 })
@@ -577,4 +586,5 @@ export const {
     _submitCommandBar: dummySubmitCommandBar,
     // Bad - I added tech debt and will fix later
     setMaxOrigLine,
+    setChatHistoryOpen,
 } = chatSlice.actions

--- a/src/index.css
+++ b/src/index.css
@@ -2445,8 +2445,8 @@ free servers .disabled_command .shortcut__block {
 
 .tipArea {
     display: flex;
-    color: #999;
-    font-size: 12px;
+    color: #b3b2b2;
+    font-size: 14px;
     align-items: center;
     margin-bottom: 4px;
 }
@@ -2456,7 +2456,7 @@ free servers .disabled_command .shortcut__block {
     background-color: #444;
     padding: 2px;
     border-radius: 2px;
-    font-size: 10px;
+    font-size: 14px;
 }
 
 .leftDrag {

--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -221,7 +221,7 @@ export async function login() {
 }
 
 export async function signup() {
-    await shell.openExternal(addRandomQueryParam(signUpUrl))    
+    await shell.openExternal(addRandomQueryParam(signUpUrl))
 }
 
 export async function pay() {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -416,7 +416,7 @@ const electronConnector = {
     },
     registerCloseErrors(callback: Callback) {
         ipcRenderer.on('closeErrors', callback)
-    }
+    },
 }
 
 contextBridge.exposeInMainWorld('connector', electronConnector)


### PR DESCRIPTION
this pr mainly focus on chat history, including:

1.  display the history list under the command bar, which happens only in chat.
2. fix the history select logic and styles. when you use ctrl + shift +↑ to browse the history prompt, you cannot get back to the initial message but only the last historical prompt.

related https://github.com/getcursor/cursor/issues/402

### display the history list under the command bar, which happens only in chat.
before & after
![imgonline-com-ua-twotoone-AtAM4PUb1YozveHr](https://user-images.githubusercontent.com/97930813/229331660-c61a8482-1bf6-4126-9a96-e86233292a2a.jpg)

### fix the history select logic and styles. can get to the initial message when use ctrl + shift +↑.
before & after

![image](https://user-images.githubusercontent.com/97930813/229332121-5b91a15e-5146-4393-b0a0-9be02d31e890.png)

### Summary Video

https://user-images.githubusercontent.com/97930813/229332145-f7ebe0be-f965-4ffe-8648-624848c7f66b.mov




