### PR TITLE
fix #424: ./setup.sh should fail gracefully on MacOS if wget is not available

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+function command_exists() {
+    command -v "$1" &> /dev/null
+}
+
+if ! command_exists wget; then
+    echo "wget is not installed. Please install wget to use this script."
+    exit 1
+fi
+
+if ! command_exists unzip; then
+    echo "unzip is not installed. Please install unzip to use this script."
+    exit 1
+fi
+
 wget https://cursor.so/resources.zip
 wget https://cursor.so/lsp.zip
 


### PR DESCRIPTION
This fix will allow ./setup.sh to fail gracefully on MacOS and Linux when 
when either "wget" or "unzip" command is not available. 
